### PR TITLE
Fix PHP version in composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -12,7 +12,7 @@
     ],
     "prefer-stable": true,
     "require": {
-        "php": "^7.1.3",
+        "php": "^7.2",
         "symfony/config": "~3.4|~4.0",
         "symfony/dependency-injection": "~3.4|~4.0",
         "symfony/http-kernel": "~3.4|~4.0",


### PR DESCRIPTION
In the FinishEvent class, you use the type hint "object" which is disponible in PHP 7.2.
This pull request fix the PHP version in the composer.json file

ref: https://wiki.php.net/rfc/object-typehint