### PR TITLE
Fix deprecation warning in Symfony 4.2

### DIFF
--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -20,8 +20,8 @@ class Configuration implements ConfigurationInterface
      */
     public function getConfigTreeBuilder()
     {
-        $treeBuilder = new TreeBuilder();
-        $rootNode = $treeBuilder->root('request_data');
+        $treeBuilder = new TreeBuilder('request_data');
+        $rootNode = \method_exists(TreeBuilder::class, 'getRootNode') ? $treeBuilder->getRootNode() : $treeBuilder->root('request_data');
 
         $rootNode->children()
             ->scalarNode('prefix')


### PR DESCRIPTION
A tree builder without a root node is deprecated since Symfony 4.2 and will not be supported anymore in 5.0.

more details:
https://symfony.com/blog/new-in-symfony-4-2-important-deprecations#deprecated-tree-builders-without-root-nodes